### PR TITLE
Fix multi-monitor peeking

### DIFF
--- a/workspacesView.js
+++ b/workspacesView.js
@@ -9,6 +9,7 @@ const SECONDARY_WORKSPACE_SCALE = 0.70;
 const OverviewControls = imports.ui.overviewControls;
 const WorkspacesView = imports.ui.workspacesView;
 const Main = imports.ui.main;
+const Gio = imports.gi.Gio;
 
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 const Util = Self.imports.util;
@@ -114,8 +115,10 @@ var SecondaryMonitorDisplayOverride = {
         const [width, height] = contentBox.get_size();
         const { expandFraction } = this._thumbnails;
         const spacing = themeNode.get_length('spacing') * expandFraction;
-        const padding =
-            Math.round((1 - SECONDARY_WORKSPACE_SCALE) * height / 2);
+        let padding = 0;
+        if (Gio.Settings.new('org.gnome.mutter').get_boolean('workspaces-only-on-primary')) {
+            padding = Math.round((1 - SECONDARY_WORKSPACE_SCALE) * height / 2);
+        }
 
         const scale = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
         const leftOffset = Main.overview._overview._controls.layoutManager.leftOffset * scale;


### PR DESCRIPTION
Scales up workspaces on secondary monitors and allows for workspace peeking on them. Before and after comparison below.
![before](https://user-images.githubusercontent.com/82644961/116729008-28f25e00-a9d6-11eb-9030-0c5954b7eef0.png)
![after](https://user-images.githubusercontent.com/82644961/116729021-2ee83f00-a9d6-11eb-96c3-1a4bac0a8043.png)
