### PR TITLE
Overview entry / exit animation

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -44,7 +44,8 @@ function reset(isDisable) {
         Util.overrideProto(Dash.Dash.prototype, global.vertical_overview.GSFunctions['Dash']);
         Util.overrideProto(Dash.DashItemContainer.prototype, global.vertical_overview.GSFunctions['DashItemContainer']);
         global.vertical_overview.dash_override = false;
-
+        this.translation_x = 0;
+        
         Util.unbindSetting('dash-max-height', () => {
             delete Main.overview._overview._controls.dashMaxHeightScale;
         });

--- a/extension.js
+++ b/extension.js
@@ -74,6 +74,7 @@ function bindSettings() {
     });
 
     Util.bindSetting('scaling-workspace-background', (settings, label) => {
+        global.vertical_overview.scaling_workspaces_hidden = settings.get_boolean(label);
         if (settings.get_boolean(label)) {
             WorkspaceOverrides.scalingWorkspaceBackgroundOverride();
         } else {

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -303,6 +303,38 @@ var ControlsManagerOverride = {
             state === ControlsState.APP_GRID;
 
         this._ignoreShowAppsButtonToggle = false;
+
+        this.dash.translation_x = -this.dash.width;
+        this.dash.ease({
+            translation_x: 0,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        this._searchEntry.opacity = 0;
+        this._searchEntry.ease({
+            opacity: 255,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+        const rightOffset = Main.overview._overview._controls.layoutManager.rightOffset * scaleFactor;
+        
+        this._thumbnailsBox.translation_x = rightOffset;
+        this._thumbnailsBox.ease({
+            translation_x: 0,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        this._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
+            if (i != Main.layoutManager.primaryIndex) {
+                let scale = Main.layoutManager.getWorkAreaForMonitor(workspace._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
+                workspace._thumbnails.translation_x = rightOffset * scale;
+                workspace._thumbnails.ease({
+                    translation_x: 0,
+                    duration: Overview.ANIMATION_TIME,
+                });
+            }
+        });
     }
 }
 
@@ -334,7 +366,7 @@ function _updateWorkspacesDisplay() {
     let initialParams = paramsForState(initialState);
     let finalParams = paramsForState(finalState);
 
-    let opacity = Math.round(Util.lerp(initialParams.opacity, finalParams.opacity, progress))
+    let opacity = Math.round(Util.lerp(initialParams.opacity, finalParams.opacity, progress));
     let scale = Util.lerp(initialParams.scale, finalParams.scale, progress);
 
     let workspacesDisplayVisible = (opacity != 0) && !(searchActive);

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -335,6 +335,50 @@ var ControlsManagerOverride = {
                 });
             }
         });
+    },
+    
+    animateFromOverview: function(callback) {
+        this._ignoreShowAppsButtonToggle = true;
+
+        this._workspacesDisplay.prepareToLeaveOverview();
+        if (!this._workspacesDisplay.activeWorkspaceHasMaximizedWindows())
+            Main.overview.fadeInDesktop();
+
+        this._stateAdjustment.ease(ControlsState.HIDDEN, {
+            duration: Overview.ANIMATION_TIME,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onStopped: () => {
+                this.dash.showAppsButton.checked = false;
+                this._ignoreShowAppsButtonToggle = false;
+
+                if (callback)
+                    callback();
+            },
+        });
+
+        this.dash.ease({
+            translation_x: -this.dash.width,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        this._searchEntry.ease({
+            opacity: 0,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        this._thumbnailsBox.ease({
+            translation_x: this._thumbnailsBox.width,
+            duration: Overview.ANIMATION_TIME,
+        });
+
+        this._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
+            if (i != Main.layoutManager.primaryIndex) {
+                workspace._thumbnails.ease({
+                    translation_x: workspace._thumbnails.width,
+                    duration: Overview.ANIMATION_TIME,
+                });
+            }
+        });
     }
 }
 

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -53,12 +53,14 @@ function reset() {
 
 function enterOverviewAnimation() {
     let controlsManager = Main.overview._overview._controls;
-    
-    controlsManager.dash.translation_x = -controlsManager.dash.width;
-    controlsManager.dash.ease({
-        translation_x: 0,
-        duration: Overview.ANIMATION_TIME,
-    });
+
+    if (global.vertical_overview.dash_override) {
+        controlsManager.dash.translation_x = -controlsManager.dash.width;
+        controlsManager.dash.ease({
+            translation_x: 0,
+            duration: Overview.ANIMATION_TIME,
+        });
+    }
             
     controlsManager._searchEntry.opacity = 0;
     controlsManager._searchEntry.ease({
@@ -68,13 +70,13 @@ function enterOverviewAnimation() {
             
     const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
     const rightOffset = controlsManager.layoutManager.rightOffset * scaleFactor;
-            
+
     controlsManager._thumbnailsBox.translation_x = rightOffset;
     controlsManager._thumbnailsBox.ease({
         translation_x: 0,
         duration: Overview.ANIMATION_TIME,
     });
-            
+    
     controlsManager._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
         if (i != Main.layoutManager.primaryIndex) {
             let scale = Main.layoutManager.getWorkAreaForMonitor(workspace._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
@@ -89,11 +91,13 @@ function enterOverviewAnimation() {
 
 function exitOverviewAnimation() {
     let controlsManager = Main.overview._overview._controls;
-    
-    controlsManager.dash.ease({
-        translation_x: -controlsManager.dash.width,
-        duration: Overview.ANIMATION_TIME,
-    });
+
+    if (global.vertical_overview.dash_override) {
+        controlsManager.dash.ease({
+            translation_x: -controlsManager.dash.width,
+            duration: Overview.ANIMATION_TIME,
+        });
+    }
     
     controlsManager._searchEntry.ease({
         opacity: 0,

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -51,6 +51,70 @@ function reset() {
     controlsManager._workspacesDisplay.setPrimaryWorkspaceVisible(true);
 }
 
+function enterOverviewAnimation() {
+    let controlsManager = Main.overview._overview._controls;
+    
+    controlsManager.dash.translation_x = -controlsManager.dash.width;
+    controlsManager.dash.ease({
+        translation_x: 0,
+        duration: Overview.ANIMATION_TIME,
+    });
+            
+    controlsManager._searchEntry.opacity = 0;
+    controlsManager._searchEntry.ease({
+        opacity: 255,
+        duration: Overview.ANIMATION_TIME,
+    });
+            
+    const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+    const rightOffset = controlsManager.layoutManager.rightOffset * scaleFactor;
+            
+    controlsManager._thumbnailsBox.translation_x = rightOffset;
+    controlsManager._thumbnailsBox.ease({
+        translation_x: 0,
+        duration: Overview.ANIMATION_TIME,
+    });
+            
+    controlsManager._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
+        if (i != Main.layoutManager.primaryIndex) {
+            let scale = Main.layoutManager.getWorkAreaForMonitor(workspace._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
+            workspace._thumbnails.translation_x = rightOffset * scale;
+            workspace._thumbnails.ease({
+                translation_x: 0,
+                duration: Overview.ANIMATION_TIME,
+            });
+        }
+    });
+}
+
+function exitOverviewAnimation() {
+    let controlsManager = Main.overview._overview._controls;
+    
+    controlsManager.dash.ease({
+        translation_x: -controlsManager.dash.width,
+        duration: Overview.ANIMATION_TIME,
+    });
+    
+    controlsManager._searchEntry.ease({
+        opacity: 0,
+        duration: Overview.ANIMATION_TIME,
+    });
+    
+    controlsManager._thumbnailsBox.ease({
+        translation_x: controlsManager._thumbnailsBox.width,
+        duration: Overview.ANIMATION_TIME,
+    });
+    
+    controlsManager._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
+        if (i != Main.layoutManager.primaryIndex) {
+            workspace._thumbnails.ease({
+                translation_x: workspace._thumbnails.width,
+                duration: Overview.ANIMATION_TIME,
+            });
+        }
+    });
+}
+
 var ControlsManagerLayoutOverride = {
     _computeWorkspacesBoxForState: function (state, box, startY, searchHeight, leftOffset, rightOffset) {
         const workspaceBox = box.copy();
@@ -301,40 +365,12 @@ var ControlsManagerOverride = {
 
         this.dash.showAppsButton.checked =
             state === ControlsState.APP_GRID;
-
-        this._ignoreShowAppsButtonToggle = false;
-
-        this.dash.translation_x = -this.dash.width;
-        this.dash.ease({
-            translation_x: 0,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        this._searchEntry.opacity = 0;
-        this._searchEntry.ease({
-            opacity: 255,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
-        const rightOffset = Main.overview._overview._controls.layoutManager.rightOffset * scaleFactor;
         
-        this._thumbnailsBox.translation_x = rightOffset;
-        this._thumbnailsBox.ease({
-            translation_x: 0,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        this._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
-            if (i != Main.layoutManager.primaryIndex) {
-                let scale = Main.layoutManager.getWorkAreaForMonitor(workspace._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
-                workspace._thumbnails.translation_x = rightOffset * scale;
-                workspace._thumbnails.ease({
-                    translation_x: 0,
-                    duration: Overview.ANIMATION_TIME,
-                });
-            }
-        });
+        this._ignoreShowAppsButtonToggle = false;
+        
+        if (global.vertical_overview.scaling_workspaces_hidden) {
+            enterOverviewAnimation();
+        }
     },
     
     animateFromOverview: function(callback) {
@@ -355,30 +391,10 @@ var ControlsManagerOverride = {
                     callback();
             },
         });
-
-        this.dash.ease({
-            translation_x: -this.dash.width,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        this._searchEntry.ease({
-            opacity: 0,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        this._thumbnailsBox.ease({
-            translation_x: this._thumbnailsBox.width,
-            duration: Overview.ANIMATION_TIME,
-        });
-
-        this._workspacesDisplay._workspacesViews.forEach((workspace, i) => {
-            if (i != Main.layoutManager.primaryIndex) {
-                workspace._thumbnails.ease({
-                    translation_x: workspace._thumbnails.width,
-                    duration: Overview.ANIMATION_TIME,
-                });
-            }
-        });
+        
+        if (global.vertical_overview.scaling_workspaces_hidden) {
+            exitOverviewAnimation();
+        }
     }
 }
 

--- a/workspace.js
+++ b/workspace.js
@@ -64,6 +64,12 @@ function scalingWorkspaceBackgroundReset() {
     if (scalingWorkspaceBackgroundEnabled) {
         _Util.overrideProto(Workspace.Workspace.prototype, global.vertical_overview.GSFunctions['Workspace']);
         scalingWorkspaceBackgroundEnabled = false;
+
+        // Ensure that variables used by overview entry / exit animation have their proper values when the animation is disabled
+        let controlsManager = Main.overview._overview._controls;
+        controlsManager.dash.translation_x = 0;
+        controlsManager._searchEntry.opacity = 255;
+        controlsManager._thumbnailsBox.translation_x = 0;
     }
 }
 

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -48,6 +48,13 @@ function thumbnails_old_style() {
 }
 
 var ThumbnailsBoxOverride = {
+    after__init: function () {
+        // A new ThumbnailsBox is created on secondary monitors every time overview is opened, so apply theme after a new one is created
+        if (global.vertical_overview.old_style_enabled && global.vertical_overview.default_old_style_enabled) {
+            this.add_style_class_name("vertical-overview");
+        }
+    },
+    
     _updateShouldShow: function() {
         const shouldShow = true;
 


### PR DESCRIPTION
Closes #68

Adds an overview transition animation to the dash, thumbnails, and search when scaling workspaces are hidden similar to GNOME 3. Also fixes the 3.38 theme not appearing on secondary monitor thumbnails.

https://user-images.githubusercontent.com/82644961/135746230-3d775fa4-f107-4e61-a454-cac1a8345dfc.mp4