### PR TITLE
Reimplement visible panel in overview

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -111,9 +111,28 @@ function bindSettings() {
 
     Util.bindSetting('panel-in-overview', (settings, label) => {
         if (settings.get_boolean(label)) {
-            Main.panel.add_style_class_name("vertical-overview");
+            if (global.vertical_overview.panel_signal_found) {
+                global.vertical_overview.panel_signal.disconnected = true;
+            } else {
+                const callbackString = "()=>{this.add_style_pseudo_class('overview');}";
+                let i = 0;
+                while (i < Main.overview._signalConnections.length) {
+                    const signal = Main.overview._signalConnections[i];
+                    if (signal.name == 'showing') {
+                        if (signal.callback.toString().replace(/[\ \n]/g, "") == callbackString) {
+                            global.vertical_overview.panel_signal = signal;
+                            global.vertical_overview.panel_signal_found = true;
+                            signal.disconnected = true;
+                            break;
+                        }
+                    }
+                    i++;
+                }
+            }
         } else {
-            Main.panel.remove_style_class_name("vertical-overview");
+            if (global.vertical_overview.panel_signal_found) {
+                global.vertical_overview.panel_signal.disconnected = false;
+            }
         }
     });
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -78,19 +78,6 @@
 	margin-left: 0px;
 }
 
-/* Top bar */
-#panel.vertical-overview {
-	background-color: #000;
-}
-
-#panel.vertical-overview .panel-corner {
-	-panel-corner-radius: 9px;
-	-panel-corner-background-color: #000;
-	-panel-corner-border-width: 2px;
-	-panel-corner-border-color: transparent;
-	-panel-corner-opacity: 1;
-}
-
 /* 3.38 style workspace thumbnails */
 .vertical-overview.workspace-thumbnails {
 	color: #eeeeec;


### PR DESCRIPTION
Fixes #75, fixes #78

Reimplements the `panel-in-overview` setting to not use any CSS, preventing a crash when locking the screen and allowing it to work with custom themes.