### PR TITLE
Static background scaling issue with multi-monitor setup.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,6 @@
         "41"
     ],
     "url" : "",
-    "uuid" : "vertical-overview-git@RensAlthuis.github.com",
+    "uuid" : "vertical-overview@RensAlthuis.github.com",
     "version" : "8"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,6 @@
         "41"
     ],
     "url" : "",
-    "uuid" : "vertical-overview@RensAlthuis.github.com",
+    "uuid" : "vertical-overview-git@RensAlthuis.github.com",
     "version" : "8"
 }

--- a/workspace.js
+++ b/workspace.js
@@ -20,40 +20,24 @@ const _Util = Self.imports.util;
 const animateAllocation = imports.ui.workspace.animateAllocation;
 
 var staticBackgroundEnabled = false;
-
-function updateStaticBackgrounds() {
-    for (var bg of global.vertical_overview.bgManagers) {
-        bg.destroy();
-    }
-
-    global.vertical_overview.bgManagers = [];
-
-    for (var monitor of Main.layoutManager.monitors) {
-        let bgManager = new Background.BackgroundManager({
-            monitorIndex: monitor.index,
-            container: Main.layoutManager.overviewGroup,
-            vignette: true,
-        });
-
-        bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
-            bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
-            bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
-        });
-
-        global.vertical_overview.bgManagers.push(bgManager);
-    }
-
-    staticBackgroundEnabled = true;
-    scalingWorkspaceBackgroundEnabled = true;
-}
-
 function staticBackgroundOverride() {
     if (!staticBackgroundEnabled) {
         global.vertical_overview.bgManagers = [];
-        monitorsChangedId = Main.layoutManager.connect('monitors-changed', () => {
-            updateStaticBackgrounds();
-        });
-        updateStaticBackgrounds();
+        for (var monitor of Main.layoutManager.monitors) {
+            let bgManager = new Background.BackgroundManager({
+                monitorIndex: monitor.index,
+                container: Main.layoutManager.overviewGroup,
+                vignette: true,
+            });
+
+            bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
+                bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
+                bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
+            });
+
+            global.vertical_overview.bgManagers.push(bgManager);
+        }
+        staticBackgroundEnabled = true;
     }
 }
 

--- a/workspace.js
+++ b/workspace.js
@@ -38,8 +38,6 @@ function updateStaticBackgrounds() {
         });
         global.vertical_overview.bgManagers.push(bgManager);
     }
-    staticBackgroundEnabled = true;
-    scalingWorkspaceBackgroundEnabled = true;
 }
 
 function staticBackgroundOverride() {

--- a/workspace.js
+++ b/workspace.js
@@ -20,24 +20,35 @@ const _Util = Self.imports.util;
 const animateAllocation = imports.ui.workspace.animateAllocation;
 
 var staticBackgroundEnabled = false;
+
+function updateStaticBackgrounds() {
+    for (var bg of global.vertical_overview.bgManagers) {
+        bg.destroy();
+    }
+    global.vertical_overview.bgManagers = [];
+    for (var monitor of Main.layoutManager.monitors) {
+        let bgManager = new Background.BackgroundManager({
+            monitorIndex: monitor.index,
+            container: Main.layoutManager.overviewGroup,
+            vignette: true,
+        });
+        bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
+            bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
+            bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
+        });
+        global.vertical_overview.bgManagers.push(bgManager);
+    }
+    staticBackgroundEnabled = true;
+    scalingWorkspaceBackgroundEnabled = true;
+}
+
 function staticBackgroundOverride() {
     if (!staticBackgroundEnabled) {
         global.vertical_overview.bgManagers = [];
-        for (var monitor of Main.layoutManager.monitors) {
-            let bgManager = new Background.BackgroundManager({
-                monitorIndex: monitor.index,
-                container: Main.layoutManager.overviewGroup,
-                vignette: true,
-            });
-
-            bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
-                bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
-                bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
-            });
-
-            global.vertical_overview.bgManagers.push(bgManager);
-        }
-        staticBackgroundEnabled = true;
+        monitorsChangedId = Main.layoutManager.connect('monitors-changed', () => {
+            updateStaticBackgrounds();
+        });
+        updateStaticBackgrounds();
     }
 }
 

--- a/workspace.js
+++ b/workspace.js
@@ -20,24 +20,40 @@ const _Util = Self.imports.util;
 const animateAllocation = imports.ui.workspace.animateAllocation;
 
 var staticBackgroundEnabled = false;
+
+function updateStaticBackgrounds() {
+    for (var bg of global.vertical_overview.bgManagers) {
+        bg.destroy();
+    }
+
+    global.vertical_overview.bgManagers = [];
+
+    for (var monitor of Main.layoutManager.monitors) {
+        let bgManager = new Background.BackgroundManager({
+            monitorIndex: monitor.index,
+            container: Main.layoutManager.overviewGroup,
+            vignette: true,
+        });
+
+        bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
+            bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
+            bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
+        });
+
+        global.vertical_overview.bgManagers.push(bgManager);
+    }
+
+    staticBackgroundEnabled = true;
+    scalingWorkspaceBackgroundEnabled = true;
+}
+
 function staticBackgroundOverride() {
     if (!staticBackgroundEnabled) {
         global.vertical_overview.bgManagers = [];
-        for (var monitor of Main.layoutManager.monitors) {
-            let bgManager = new Background.BackgroundManager({
-                monitorIndex: monitor.index,
-                container: Main.layoutManager.overviewGroup,
-                vignette: true,
-            });
-
-            bgManager._fadeSignal = Main.overview._overview._controls._stateAdjustment.connect('notify::value', (v) => {
-                bgManager.backgroundActor.content.vignette_sharpness = Util.lerp(0, 0.6, Math.min(v.value, 1));
-                bgManager.backgroundActor.content.brightness = Util.lerp(1, 0.75, Math.min(v.value, 1));
-            });
-
-            global.vertical_overview.bgManagers.push(bgManager);
-        }
-        staticBackgroundEnabled = true;
+        monitorsChangedId = Main.layoutManager.connect('monitors-changed', () => {
+            updateStaticBackgrounds();
+        });
+        updateStaticBackgrounds();
     }
 }
 


### PR DESCRIPTION
If you have multiple monitors and turned on "static background" plus "hide scaling worksplaces" you will experience that if one of the monitors is unplugged and then plugged back in that the background will not fill correctly the desktop when you bring up the workspaces. To overcome this issue this patch uses some code brought from cosmic-workspaces which listens to monitor changes and updates the static backgrounds accordingly.

With 2 or more monitors hooked-up, bring up workspaces:
![Screenshot from 2022-02-21 11-13-02](https://user-images.githubusercontent.com/25939765/154975188-85f82eb6-5dc1-4cde-a99c-299ca3b3bdf6.png)

Unplug one of the monitors and open workspaces again:
![Screenshot from 2022-02-21 11-12-28](https://user-images.githubusercontent.com/25939765/154975319-05dc0b07-3b9d-4b21-ac6b-55e70f803eed.png)

