### PR TITLE
set url in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
     "shell-version" : [
         "42"
     ],
-    "url" : "",
+    "url" : "https://github.com/RensAlthuis/vertical-overview",
     "uuid" : "vertical-overview@RensAlthuis.github.com",
     "version" : "8"
 }


### PR DESCRIPTION
This should help people find more easily the source code from the Gnome extensions website.