### PR TITLE
Revert "Scale workspace thumbnails by theme scale factor"

### DIFF
--- a/overviewControls.js
+++ b/overviewControls.js
@@ -180,9 +180,8 @@ var ControlsManagerLayoutOverride = {
     vfunc_allocate: function(container, box) {
         const childBox = new Clutter.ActorBox();
 
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
-        var leftOffset = this.leftOffset * scaleFactor;
-        let rightOffset = this.rightOffset * scaleFactor;
+        var leftOffset = this.leftOffset;
+        let rightOffset = this.rightOffset;
 
         const { spacing } = this;
 

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -124,10 +124,9 @@ var SecondaryMonitorDisplayOverride = {
         const padding =
             Math.round((1 - SECONDARY_WORKSPACE_SCALE) * height / 2);
 
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
         const scale = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width;
-        const leftOffset = Main.overview._overview._controls.layoutManager.leftOffset * scale * scaleFactor;
-        const rightOffset = Main.overview._overview._controls.layoutManager.rightOffset * scale * scaleFactor;
+        const leftOffset = Main.overview._overview._controls.layoutManager.leftOffset * scale;
+        const rightOffset = Main.overview._overview._controls.layoutManager.rightOffset * scale;
 
         // Workspace Thumbnails
         if (this._thumbnails.visible) {


### PR DESCRIPTION
This reverts commit f8d3431320aef5efee06189e90a86ca2fb370aca.

Scaling workspace thumbnails without making more space for them would
render them behind the window selection.

Resolves #109.