### PR TITLE
Add shell-version tag fro gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "original-author": "rens.althuis@gmail.com",
     "shell-version" : [
         "42",
-        "43"
+        "43",
+	"44"
     ],
     "url" : "https://github.com/RensAlthuis/vertical-overview",
     "uuid" : "vertical-overview@RensAlthuis.github.com",


### PR DESCRIPTION
Vertical-overview stopped working once I upgraded to Fedora 38 (Gnome 44).
This simple "fix" seemed to have enabled it to work on Gnome 44.